### PR TITLE
Added extra test case to test if assume was properly parsed

### DIFF
--- a/test/ParseSpec.hs
+++ b/test/ParseSpec.hs
@@ -333,3 +333,16 @@ rubric = do
           ]
         }
       ]
+      
+    check "programs/pos/inc0.js" 
+      [ Function 
+        { fname = "inc"
+        , fargs = ["x"]
+        , fbody = Seq [Assume (Pred (Var ("x" :@ 0) :>=: Const 1))
+        , Assign "y" (BinOp Add (Var ("x" :@ 0)) (Const 1))
+        , Assert (Pred (Var ("y" :@ 0) :>=: Const 1))]
+        , fpre = And []
+        , fpost = And []
+        , fmods = []
+        }
+      ]


### PR DESCRIPTION
When working on the assignment my vcgen was failing in some places with no clear cause. After a bunch of debugging I noticed I just forgot to parse statement "assume". I found this by creating tests of my own to test the failing function.

So I thought maybe id be a good idea to add it to the test suite for (next) students like me who forget obvious things, since I already wrote the test anyway.